### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This project relies on the following packages:
 | Package               | Description                                                      | Usage                                          |
 |-----------------------|------------------------------------------------------------------|------------------------------------------------|
 | tiktoken              | OpenAI's tokenizer for text tokenization                         | Text encoding for LLM input                    |
-| pyautogen             | Framework for building autonomous AI agents                      | Creating agent-based systems                   |
+| ag2             | Framework for building autonomous AI agents                      | Creating agent-based systems                   |
 | transformers          | Hugging Face's NLP library                                         | Working with state-of-the-art language models  |
 | sentence-transformers | Specialized transformers for sentence embeddings                 | Creating semantic text embeddings              |
 | scikit-learn          | Machine learning library                                           | Classical ML algorithms and utilities          |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pip install -r requirements.txt
 tiktoken
-pyautogen
+ag2
 transformers
 sentence-transformers
 scikit-learn


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
